### PR TITLE
feat: add MLOps module, modern LLM packages, and deprecate MXNet

### DIFF
--- a/Packages.md
+++ b/Packages.md
@@ -3,11 +3,15 @@
 This README provides an overview of the most common libraries used in data science, machine learning, computer vision, and deep learning, along with instructions on how to install them using `pip`.
 
 ## Table of Contents
-1. [Data Science Libraries](#data-science-libraries)
-2. [Machine Learning Libraries](#machine-learning-libraries)
-3. [Computer Vision Libraries](#computer-vision-libraries)
-4. [Deep Learning Libraries](#deep-learning-libraries)
-5. [Installation Instructions](#installation-instructions)
+- [Commonly Used AI/ML Python Libraries](#commonly-used-aiml-python-libraries)
+  - [Table of Contents](#table-of-contents)
+  - [Data Science Libraries](#data-science-libraries)
+  - [Machine Learning Libraries](#machine-learning-libraries)
+  - [Computer Vision Libraries](#computer-vision-libraries)
+  - [Deep Learning Libraries](#deep-learning-libraries)
+- [Installation Instructions](#installation-instructions)
+    - [Example Installation](#example-installation)
+  - [Additional Resources](#additional-resources)
 
 💡Incase you have installed pip and want to download all packages in one go without reading much about it, run this command directly onto your terminal:
 ```sh

--- a/resources/README.md
+++ b/resources/README.md
@@ -1,1 +1,20 @@
-Additional resources to learn.
+# Resources
+
+This folder contains additional offline learning materials to supplement the roadmap.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [Generative-AI-and-LLMs-for-Dummies.pdf](./Generative-AI-and-LLMs-for-Dummies.pdf) | A beginner-friendly e-book covering the fundamentals of Generative AI and Large Language Models. Covers key concepts like transformers, prompt engineering, and real-world applications. Referenced in [Module 7 - Generative AI](../README.md#module-7---generative-ai). |
+
+## Contributing Resources
+
+Have a useful PDF, cheat sheet, or offline guide to add?
+
+1. Keep file sizes reasonable (ideally under 10MB).
+2. Only add content that is freely distributable (open license, or explicitly marked as free).
+3. Update this README table when you add a new file.
+4. Reference the new resource in the relevant module in the main [README.md](../README.md).
+
+See the [CONTRIBUTING guide](../CONTRIBUTING.md) for full instructions.


### PR DESCRIPTION
## Problem
The roadmap was missing the entire production side of ML (MLOps/deployment), 
had no coverage of the HuggingFace ecosystem or LangChain despite these being 
industry-standard in 2024+, listed MXNet as a viable deep learning library 
despite Apache retiring it in 2023, and the Module 0 setup section didn't 
mention Google Colab or Miniconda — the most common free GPU and env 
management tools for beginners.

## Solution
Added a dedicated Module 11 (MLOps & Deployment), expanded the package 
reference to cover the modern LLM and MLOps stack, flagged and deprecated 
MXNet with a clear note directing learners to PyTorch/TensorFlow, and 
strengthened Module 0, 4, and 7 with missing high-value free resources.

## Changes

**`README.md`**
- Added Module 11 - MLOps & Deployment (8 resources: MLOps Zoomcamp, DeepLearning.AI MLOps Specialization, MLflow, W&B, FastAPI+Docker deployment, Gradio, Streamlit, Full Stack Deep Learning)
- Module 0: Added Google Colab and Miniconda to setup table
- Module 4: Added fast.ai and Kaggle Learn
- Module 7: Added HuggingFace NLP Course, fine-tuning/LoRA tutorial, and Ollama for local LLMs
- Updated ToC to include Module 11

**`Packages.md`**
- New section: LLM & Agentic AI Libraries (transformers, datasets, sentence-transformers, langchain, langgraph, faiss-cpu, chromadb)
- New section: MLOps & Deployment Libraries (mlflow, wandb, gradio, streamlit)
- Flagged MXNet as archived/deprecated with explanation
- Updated bulk `pip install` command to remove MXNet and include new packages
- Added documentation links for all new libraries

**`resources/README.md`**
- Replaced one-line placeholder with a proper contents table and contributor instructions

## Notes / Tradeoffs
- MXNet is flagged rather than removed entirely, to preserve git history and for users who may already have it installed from following older versions of this guide.
- LangGraph is included separately from LangChain since it's now the recommended path for agentic workflows, though it adds a dependency.